### PR TITLE
update native SDKs and add browser info to confirm payment params

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ const result = await MonriAndroidIos.confirmPayment({
       fullName: 'Test Test',
       zip: '71210',
     },
+    // optional 3DS browser info — omitted fields (or the whole object)
+    // are resolved automatically by the native SDK
+    browserInfo: {
+      language: 'en',
+      timeZoneOffset: -60,
+    },
   });
 ```
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -129,6 +129,6 @@ repositories {
 dependencies {
   implementation "com.google.android.gms:play-services-wallet:19.4.0"
   implementation "com.facebook.react:react-android:0.80.0"
-  implementation 'com.monri:monri-android:3.1.1'
+  implementation 'com.monri:monri-android:3.2.2'
   implementation 'androidx.preference:preference:1.2.1'
 }

--- a/android/src/main/java/com/reactnativemonriandroidios/MonriAndroidIosModule.kt
+++ b/android/src/main/java/com/reactnativemonriandroidios/MonriAndroidIosModule.kt
@@ -66,7 +66,7 @@ class MonriAndroidIosModule(
 
       this.confirmPaymentPromise = promise
 
-      val parseResult = MonriMapper.parseConfirmPaymentParams(params)
+      val parseResult = MonriMapper.parseConfirmPaymentParams(reactApplicationContext, params)
       val confirmPaymentParams = parseResult.params
       this.googlePayButtonOptions = parseResult.googlePayButtonOptions
 
@@ -85,7 +85,7 @@ class MonriAndroidIosModule(
           }
         }
 
-      if (MonriMapper.parseConfirmPaymentParams(params).googlePayButtonOptions != null) {
+      if (parseResult.googlePayButtonOptions != null) {
          if (this.googlePayButtonOptions != null) {
              this.monri.confirmPayment(
                  confirmPaymentParams,

--- a/android/src/main/java/com/reactnativemonriandroidios/MonriConstants.kt
+++ b/android/src/main/java/com/reactnativemonriandroidios/MonriConstants.kt
@@ -42,6 +42,19 @@ object MonriConstants {
     const val KEY_ORDER_INFO = "orderInfo"
     const val KEY_AUTHENTICITY_TOKEN = "authenticityToken"
     const val KEY_DEVELOPMENT_MODE = "developmentMode"
+
+    // Browser Info Keys
+    const val KEY_BROWSER_INFO = "browserInfo"
+    const val KEY_SCREEN_WIDTH = "screenWidth"
+    const val KEY_SCREEN_HEIGHT = "screenHeight"
+    const val KEY_COLOR_DEPTH = "colorDepth"
+    const val KEY_USER_AGENT = "userAgent"
+    const val KEY_TIME_ZONE_OFFSET = "timeZoneOffset"
+    const val KEY_LANGUAGE = "language"
+    const val KEY_JAVA_ENABLED = "javaEnabled"
+    const val KEY_HTTP_ACCEPT = "httpAccept"
+    const val KEY_HTTP_USER_AGENT = "httpUserAgent"
+    const val KEY_HTTP_ACCEPT_LANGUAGE = "httpAcceptLanguage"
     
     // Payment Types
     const val TYPE_GOOGLE_PAY = "googlePay"

--- a/android/src/main/java/com/reactnativemonriandroidios/MonriMapper.kt
+++ b/android/src/main/java/com/reactnativemonriandroidios/MonriMapper.kt
@@ -1,5 +1,6 @@
 package com.reactnativemonriandroidios
 
+import android.content.Context
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeArray
@@ -14,7 +15,7 @@ object MonriMapper {
         val googlePayButtonOptions: GooglePayButtonOptions?
     )
 
-    fun parseConfirmPaymentParams(params: ReadableMap): ConfirmPaymentParseResult {
+    fun parseConfirmPaymentParams(context: Context, params: ReadableMap): ConfirmPaymentParseResult {
         val clientSecret = getRequiredString(params, MonriConstants.KEY_CLIENT_SECRET)
         val transactionParams = params.getMap(MonriConstants.KEY_TRANSACTION)
             ?: throw RequiredAttributeException(MonriConstants.ERROR_TRANSACTION_MISSING)
@@ -93,7 +94,51 @@ object MonriMapper {
                 .set(MonriConstants.KEY_ORDER_INFO, transactionParams.getString(MonriConstants.KEY_ORDER_INFO))
         )
 
+        if (params.hasKey(MonriConstants.KEY_BROWSER_INFO)) {
+            params.getMap(MonriConstants.KEY_BROWSER_INFO)?.let { browserInfoParams ->
+                confirmPaymentParams.setBrowserInfo(parseBrowserInfo(context, browserInfoParams))
+            }
+        }
+
         return ConfirmPaymentParseResult(confirmPaymentParams, googlePayButtonOptions)
+    }
+
+    private fun parseBrowserInfo(context: Context, params: ReadableMap): BrowserInfo {
+        // Fields not provided from JS keep the SDK-resolved defaults
+        val browserInfo = BrowserInfo.create(context)
+
+        if (params.hasKey(MonriConstants.KEY_SCREEN_WIDTH)) {
+            browserInfo.setScreenWidth(params.getInt(MonriConstants.KEY_SCREEN_WIDTH))
+        }
+        if (params.hasKey(MonriConstants.KEY_SCREEN_HEIGHT)) {
+            browserInfo.setScreenHeight(params.getInt(MonriConstants.KEY_SCREEN_HEIGHT))
+        }
+        if (params.hasKey(MonriConstants.KEY_COLOR_DEPTH)) {
+            browserInfo.setColorDepth(params.getInt(MonriConstants.KEY_COLOR_DEPTH))
+        }
+        getNullableString(params, MonriConstants.KEY_USER_AGENT)?.let {
+            browserInfo.setUserAgent(it)
+        }
+        if (params.hasKey(MonriConstants.KEY_TIME_ZONE_OFFSET)) {
+            browserInfo.setTimeZoneOffset(params.getInt(MonriConstants.KEY_TIME_ZONE_OFFSET))
+        }
+        getNullableString(params, MonriConstants.KEY_LANGUAGE)?.let {
+            browserInfo.setLanguage(it)
+        }
+        if (params.hasKey(MonriConstants.KEY_JAVA_ENABLED)) {
+            browserInfo.setJavaEnabled(params.getBoolean(MonriConstants.KEY_JAVA_ENABLED))
+        }
+        getNullableString(params, MonriConstants.KEY_HTTP_ACCEPT)?.let {
+            browserInfo.setHttpAccept(it)
+        }
+        getNullableString(params, MonriConstants.KEY_HTTP_USER_AGENT)?.let {
+            browserInfo.setHttpUserAgent(it)
+        }
+        getNullableString(params, MonriConstants.KEY_HTTP_ACCEPT_LANGUAGE)?.let {
+            browserInfo.setHttpAcceptLanguage(it)
+        }
+
+        return browserInfo
     }
 
     fun parseMonriApiOptions(params: ReadableMap): MonriApiOptions {

--- a/ios/MonriAndroidIos.swift
+++ b/ios/MonriAndroidIos.swift
@@ -167,7 +167,38 @@ class MonriAndroidIos: NSObject {
             .set(customerParams: customerParams)
             .set("order_info", transactionParams["orderInfo"] as? String)
 
+        if let browserInfo = parseBrowserInfo(params) {
+            return ConfirmPaymentParams(
+                paymentId: clientSecret,
+                paymentMethod: paymentMethod,
+                transaction: transaction,
+                browserInfo: browserInfo
+            )
+        }
+
         return ConfirmPaymentParams(paymentId: clientSecret, paymentMethod: paymentMethod, transaction: transaction)
+    }
+
+    private func parseBrowserInfo(_ params: [String: Any]) -> BrowserInfo? {
+        guard let browserInfoParams = params["browserInfo"] as? [String: Any] else {
+            return nil
+        }
+
+        // Fields not provided from JS keep the SDK-resolved defaults
+        let defaults = BrowserInfo.create().toJSON()
+
+        return BrowserInfo(
+            screenWidth: browserInfoParams["screenWidth"] as? Int ?? defaults["screen_width"] as? Int ?? 0,
+            screenHeight: browserInfoParams["screenHeight"] as? Int ?? defaults["screen_height"] as? Int ?? 0,
+            colorDepth: browserInfoParams["colorDepth"] as? Int ?? defaults["color_depth"] as? Int ?? 24,
+            userAgent: browserInfoParams["userAgent"] as? String ?? defaults["user_agent"] as? String ?? "",
+            timeZoneOffset: browserInfoParams["timeZoneOffset"] as? Int ?? defaults["time_zone_offset"] as? Int ?? 0,
+            language: browserInfoParams["language"] as? String ?? defaults["language"] as? String ?? "",
+            javaEnabled: browserInfoParams["javaEnabled"] as? Bool ?? defaults["java_enabled"] as? Bool ?? false,
+            httpAccept: browserInfoParams["httpAccept"] as? String ?? defaults["http_accept"] as? String ?? "*/*",
+            httpUserAgent: browserInfoParams["httpUserAgent"] as? String ?? defaults["http_user_agent"] as? String ?? "",
+            httpAcceptLanguage: browserInfoParams["httpAcceptLanguage"] as? String ?? defaults["http_accept_language"] as? String ?? ""
+        )
     }
 
     private func writeMetaData() {

--- a/react-native-monri-android-ios.podspec
+++ b/react-native-monri-android-ios.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency 'Monri', '2.3.3'
+  s.dependency 'Monri', '2.3.4'
 end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,12 +67,31 @@ export type SavedCard = {
   cvv: string;
 };
 
+/**
+ * 3DS browser (device) info sent with confirmPayment.
+ * All fields are optional — any field not provided is
+ * resolved automatically by the native SDK.
+ */
+export type BrowserInfo = {
+  screenWidth?: number;
+  screenHeight?: number;
+  colorDepth?: number;
+  userAgent?: string;
+  timeZoneOffset?: number;
+  language?: string;
+  javaEnabled?: boolean;
+  httpAccept?: string;
+  httpUserAgent?: string;
+  httpAcceptLanguage?: string;
+};
+
 export type ConfirmPaymentParams = {
   type: string;
   clientSecret: string;
   card?: Card;
   savedCard?: SavedCard;
   transaction: Transaction;
+  browserInfo?: BrowserInfo;
   googlePayButtonOptions?: GooglePayButtonOptions;
   pkPaymentButtonType?: number | null;
   pkPaymentButtonStyle?: number | null;


### PR DESCRIPTION
- Bump monri-android 3.1.1 -> 3.2.2 and Monri iOS pod 2.3.3 -> 2.3.4
- Expose optional browserInfo on ConfirmPaymentParams (JS), mapped to the native BrowserInfo API on both platforms; omitted fields fall back to SDK-resolved defaults